### PR TITLE
Minimal kernel to write to VGA buffer

### DIFF
--- a/.cargo/config
+++ b/.cargo/config
@@ -1,2 +1,15 @@
 [target.'cfg(target_os = "macos")']
 rustflags = ["-C", "link-args=-e __start -static -nostartfiles"]
+
+# Allow "cargo xbuild" to build for the following target.
+# This allows us to not pass "--target TARGET" argument every time to
+# Cargo.
+[build]
+target = "x86_64-rustos.json"
+
+# Enable running the OS with just "cargo xrun"
+[target.'cfg(target_os = "none")']
+# bootimage's runner sub-command actually invokes QEMU to run the OS.
+# See:
+# https://github.com/rust-osdev/bootimage/blob/master/Readme.md
+runner = "bootimage runner"

--- a/.gitignore
+++ b/.gitignore
@@ -16,3 +16,6 @@ Cargo.lock
 
 /target
 #**/*.rs.bk
+
+# Tags file
+rusty-tags.vi

--- a/Cargo.toml
+++ b/Cargo.toml
@@ -10,3 +10,6 @@ edition = "2018"
 panic = "abort"
 [profile.release]
 panic = "abort"
+
+[dependencies]
+bootloader = "0.8.0"

--- a/rusty-tags.vi
+++ b/rusty-tags.vi
@@ -1,8 +1,0 @@
-!_TAG_FILE_FORMAT	2	/extended format; --format=1 will not append ;" to lines/
-!_TAG_FILE_SORTED	1	/0=unsorted, 1=sorted, 2=foldcase/
-!_TAG_PROGRAM_AUTHOR	Darren Hiebert	/dhiebert@users.sourceforge.net/
-!_TAG_PROGRAM_NAME	Exuberant Ctags	//
-!_TAG_PROGRAM_URL	http://ctags.sourceforge.net	/official site/
-!_TAG_PROGRAM_VERSION	5.8	//
-_start	/Users/aradhana/projects/rustos/src/main.rs	/^pub extern "C" fn _start() -> ! {$/;"	f
-panic	/Users/aradhana/projects/rustos/src/main.rs	/^fn panic(_info: &PanicInfo) -> ! {$/;"	f

--- a/src/main.rs
+++ b/src/main.rs
@@ -17,15 +17,40 @@ fn panic(_info: &PanicInfo) -> ! {
     loop {}
 }
 
+static HELLO: &[u8] = b"Hello, world!";
+
 // Instruct the Rust compiler to not not mangle the name of this
 // function as we actually need a function named "_start()". Without
 // this attribute, compiler would garble this function's name to ensure
 // function name uniqueness.
 #[no_mangle]
-// This is the entry point. Linker looks for a function named '_start()'.
+// This is the entry point. Linker looks for a function named
+// '_start()'.
 //
 // 'extern "C"' tells the compiler to use C calling convention instead
 // of Rust calling convention.
 pub extern "C" fn _start() -> ! {
+    // VGA text buffer starting address is 0xb8000.
+    let vga_buf = 0xb8000 as *mut u8;
+
+    // Set the VGA text buffer to data pointed by HELLO.
+    //
+    // Each character is represented by two bytes:
+    //  - byte0: character code point
+    //  - byte1: control byte with bitfields for colour, blinking, etc.
+    //
+    // Set the colour to 0xb (Cyan).
+    //
+    // See https://en.wikipedia.org/wiki/VGA-compatible_text_mode#Text_buffer
+    for (i, &byte) in HELLO.iter().enumerate() {
+        // We are directly writing to VGA text buffer address. Rust
+        // compiler has no way of guaranteeing safety, and thus 'unsafe'
+        // is required.
+        unsafe {
+            *vga_buf.offset(i as isize * 2) = byte;
+            *vga_buf.offset(i as isize * 2 + 1) = 0xb;
+        }
+    }
+
     loop {}
 }

--- a/x86_64-rustos.json
+++ b/x86_64-rustos.json
@@ -1,0 +1,15 @@
+{
+    "llvm-target": "x86_64-unknown-none",
+    "data-layout": "e-m:e-i64:64-f80:128-n8:16:32:64-S128",
+    "arch": "x86_64",
+    "target-endian": "little",
+    "target-pointer-width": "64",
+    "target-c-int-width": "32",
+    "os": "none",
+    "executables": true,
+    "linker-flavor": "ld.lld",
+    "linker": "rust-lld",
+    "disable-redzone": true,
+    "panic-strategy": "abort",
+    "features": "-mmx,-sse,+soft-float"
+}


### PR DESCRIPTION
Simple kernel that writes a string to VGA text buffer at 0xb8000.

'bootloader' crate is used to create a bootimage instead of writing our
own.

A new target triple is created via JSON. Cargo config is updated to
build/run for the new target by default using 'xbuild' and 'xrun'.

https://os.phil-opp.com/minimal-rust-kernel/